### PR TITLE
Updated periodic payment api endpoints.

### DIFF
--- a/securepay.php
+++ b/securepay.php
@@ -817,7 +817,7 @@ class SecurePay {
 			trigger_error('You do not have Curl installed on this server', E_USER_ERROR);
 		$curl = curl_init();
 		if ($this->IsRepeat()) { // Periodic payment
-			$url = ($this->TestMode) ? 'https://www.securepay.com.au/test/periodic' : 'https://www.securepay.com.au/xmlapi/periodic';
+			$url = ($this->TestMode) ? 'https://test.securepay.com.au/xmlapi/periodic' : 'https://api.securepay.com.au/xmlapi/periodic';
 		} else // Once-off payment
 			$url = ($this->TestMode) ? 'https://test.securepay.com.au/xmlapi/payment' : 'https://api.securepay.com.au/xmlapi/payment';
 


### PR DESCRIPTION
Periodic transactions are breaking with the test gateway. I updated the endpoint to the one specified in the latest securepay docs - https://www.securepay.com.au/developers/integration-guides - and everything was working again.

I've updated the live gateway endpoint in the same manner. I imagine securepay have left the legacy endpoint working for the live gateway but not the test gateway.

Thanks for the API btw!